### PR TITLE
Freezes flexirest at 1.2.0 since newer versions break compatibility

### DIFF
--- a/nfg-rest-client.gemspec
+++ b/nfg-rest-client.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport", '~> 4.0'
   spec.add_dependency "json"
-  spec.add_dependency "flexirest"
+  spec.add_dependency "flexirest", '~> 1.2.0'
 end


### PR DESCRIPTION
Flexirest hit version 1.3 in late February of this year. Since we weren't specifying a version string in the gemspec, installing the nfs-rest-client gem automatically installs a 1.3 version of flexirest. Unfortunately, it seems that there are some compatibility issues between our gem and flexirest 1.3. In the Givecorps app, I get this error in one of the specs:

```
"[\"undefined method `_filter_request' for NfgRestClient::Donation:Class\"]"
```

Reverting to the latest 1.2 version of flexirest fixes the problem.
